### PR TITLE
upgrade to influxdb2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,24 +29,29 @@ Add support for ModbusTCP and add bridge RTU to TCP vía ESP8266 and multi Influ
 ##### Step-by-step instructions
 * Add the InfluxData repository
     ```sh
-    $ curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
-    $ source /etc/os-release
-    $ test $VERSION_ID = "11" && echo "deb https://repos.influxdata.com/debian bullseye stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+    $ wget -q https://repos.influxdata.com/influxdata-archive_compat.key
+    $ echo '393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c influxdata-archive_compat.key' | sha256sum -c && cat influxdata-archive_compat.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg > /dev/null
+    $ echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
     ```
 * Download and install
     ```sh
-    $ sudo apt-get update && sudo apt-get install influxdb
+    $ sudo apt-get update && sudo apt-get install influxdb2
     ```
 * Start the influxdb service
     ```sh
-    $ sudo service influxdb start
+    $ sudo systemctl start influxdb
     ```
-* Create the database
+* Create the database (databases are named buckets in influxdb2)
     ```sh
-    $ influx
-    CREATE DATABASE db_modbus
-    exit
+    $  influx bucket create -n db_modbus --org myorg
     ```
+    or user webui at `http://localhost:8086`
+* Create a token
+    ```sh
+    $ influx auth create -o myorg --all-access
+    ```
+    or user webui at `http://localhost:8086`
+
 [*source](https://docs.influxdata.com/influxdb/v1.8/introduction/installation/)
 
 #### Install Grafana*

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add support for ModbusTCP and add bridge RTU to TCP vía ESP8266 and multi Influ
 * Python 3.4 and PIP3
 * PyYAML 5.1 (pip3 install -U PyYAML if installed)
 * [modbus_tk](https://github.com/ljean/modbus-tk)
-* [InfluxDB](https://docs.influxdata.com/influxdb/v1.3/)
+* [InfluxDB](https://docs.influxdata.com/influxdb/v2.7/)
 * [Grafana](http://docs.grafana.org/)
 
 ### Prerequisite
@@ -52,7 +52,7 @@ Add support for ModbusTCP and add bridge RTU to TCP vía ESP8266 and multi Influ
     ```
     or user webui at `http://localhost:8086`
 
-[*source](https://docs.influxdata.com/influxdb/v1.8/introduction/installation/)
+[*manual installation without apt](https://docs.influxdata.com/influxdb/v2.7/install/)
 
 #### Install Grafana*
 

--- a/influx_config.yml
+++ b/influx_config.yml
@@ -1,8 +1,7 @@
 influxdb:
     - name : Local InfluxDB 
-      host : 'localhost'
-      port : 8086
-      user : 'root'
-      password : 'root'
-      dbname : 'db_modbus'
+      url : 'http://localhost:8086'
+      token: 'WW91ciBiYXNlNjQgZW5jb2RlZCB0b2tlbiBnb2VzIGhlcmUu' #Your base64 encoded token goes here.
+      org: 'myorg'
+      dbname : 'db_modbus' #keep in mind that dbname will be db_modbus/autogen after upgrading form 1.8 to 2.x
       interval : 1

--- a/read_modbus_device.py
+++ b/read_modbus_device.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-from influxdb import InfluxDBClient
+from influxdb_client import InfluxDBClient
+from influxdb_client.client.write_api import SYNCHRONOUS
 from datetime import datetime, timedelta
 from os import path
 import sys
@@ -30,7 +31,7 @@ class DataCollector:
         self.influx_inteval_save = dict()
         log.info('InfluxDB:')
         for influx_config in sorted(self.get_influxdb(), key=lambda x:sorted(x.keys())):
-            log.info('\t {} <--> {}'.format(influx_config['host'], influx_config['name']))
+            log.info('\t {} <--> {}'.format(influx_config['url'], influx_config['name']))
         self.device_yaml = device_yaml
         self.max_iterations = None  # run indefinitely by default
         self.device_map = None
@@ -102,7 +103,7 @@ class DataCollector:
 
                     for parameter in parameters:
                         # If random readout errors occour, e.g. CRC check fail, test to uncomment the following row
-                        time.sleep(0.5) # Sleep for 500 ms between each parameter read to avoid errors
+                        #time.sleep(0.5) # Sleep for 500 ms between each parameter read to avoid errors
                         retries = 10
                         while retries > 0:
                             try:
@@ -280,13 +281,10 @@ class DataCollector:
                     if self.influx_inteval_save[list] <= 1:
                         self.influx_inteval_save[list] = influx_config['interval']
 
-                        DBclient = InfluxDBClient(influx_config['host'],
-                                                influx_config['port'],
-                                                influx_config['user'],
-                                                influx_config['password'],
-                                                influx_config['dbname'])
+                        DBclient = InfluxDBClient(url=influx_config['url'], token=influx_config['token'], org=influx_config['org'])
+                        write_api = DBclient.write_api(write_options=SYNCHRONOUS)
                         try:
-                            DBclient.write_points(json_body)
+                            write_api.write(bucket=influx_config['dbname'],org=influx_config['org'],record=json_body)
                             log.info(t_str + ' Data written for %d meters in {}.' .format(influx_config['name']) % len(json_body) )
                         except Exception as e:
                             log.error('Data not written! in {}' .format(influx_config['name']))

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='modbus_logger',
         'Programming Language :: Python :: 3.5'
       ],
       keywords='Logger RS485 Modbus',
-      install_requires=[]+(['setuptools','ez_setup','pyserial','modbus_tk', 'influxdb', 'pyyaml'] if "linux" in sys.platform else []),
+      install_requires=[]+(['setuptools','ez_setup','pyserial','modbus_tk', 'influxdb-client', 'pyyaml'] if "linux" in sys.platform else []),
       license='MIT',
       packages=[],
       include_package_data=True,


### PR DESCRIPTION
Since influxdb1.8 runs unsupported since 2021, I've updated this script to influxdb2.

The upgrading process is **not** as straightforward as [this](https://docs.influxdata.com/influxdb/v2.7/upgrade/v1-to-v2/automatic-upgrade/) might suggest: user/password is replaced by tokens, databases are now named buckets, and you'll have to name an organization. What gave me the most headache is, that the database will be named "db_modbus/autogen" after the upgrade (but you can rename the bucket to "db_modbus" after migration.

The other headache was the grafana connection: You'll need to add a Custom HTTP Headers "Authorization" with "**Token** WW91ciBiYXNlNjQgZW5jb2RlZCB0b2tlbiBnb2VzIGhlcmUu".